### PR TITLE
Override flowdock config with checks and clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,22 @@
  * bin/handler-flowdock.rb
 
 ## Usage
-
+flowdock.json
 ```
 {
   "flowdock": {
-    "auth_token": "FLOWDOCK_API_TOKEN"
+    "auth_token": "FLOWDOCK_API_TOKEN",
+    "tags" : ["sensu", "my-team"], // Optional, deafults to ['sensu']
+    "user_name" : "Status" // Optional, defaults to 'Sensu'
   }
 }
 ```
+
+auth_token is the only required parameter.
+
+Optionally include an auth token, list of tags, or user name in the client
+or check to override the global config.
+
 
 ## Installation
 

--- a/bin/handler-flowdock.rb
+++ b/bin/handler-flowdock.rb
@@ -3,8 +3,23 @@
 # Sensu Flowdock (https://www.flowdock.com/api/chat) notifier
 # This handler sends event information to the Flowdock Push API: Chat.
 # The handler pushes event output to chat:
-# This setting is required in flowdock.json
-#   auth_token  :  The flowdock api token (flow_api_token)
+
+# Input:
+# json_config["flowdock"] (i.e. flowdock.json)
+#   auth_token : The flowdock api token (flow_api_token) REQUIRED
+#   tags       : List of tags to apply to the posted message. Defaults to ['sensu']
+#   user_name  : User name used to send event.  Defaults to 'Sensu'
+#
+# @event['client']
+#   flowdock_auth_token : Override the default token on a per-client basis
+#   flowdock_tags : Override the tags on a per-client basis
+#   flowdock_user : Override the user on a per-client basis
+#
+# @event['check']
+#   flowdock_auth_token : Override the default token on a per-check basis
+#   flowdock_tags : Override the tags on a per-check basis
+#   flowdock_user : Override the user on a per-check basis
+#
 #
 # Dependencies
 # -----------
@@ -22,9 +37,13 @@ require 'flowdock'
 
 class FlowdockNotifier < Sensu::Handler
   def handle
-    token = settings['flowdock']['auth_token']
+    token = @event['client']['flowdock_auth_token'] || @event['check']['flowdock_auth_token'] || settings['flowdock']['auth_token']
+    tags = @event['client']['flowdock_tags'] || @event['check']['flowdock_tags'] || settings['flowdock']['tags'] || %w(sensu)
+    user_name = @event['client']['flowdock_user_name'] || @event['check']['flowdock_user_name'] || settings['flowdock']['user_name'] || 'Sensu'
+
     data = @event['check']['output']
-    flow = Flowdock::Flow.new(api_token: token, external_user_name: 'Sensu')
-    flow.push_to_chat(content: data, tags: %w(sensu test))
+
+    flow = Flowdock::Flow.new(api_token: token, external_user_name: user_name)
+    flow.push_to_chat(content: data, tags: tags)
   end
 end

--- a/sensu-plugins-flowdock.gemspec
+++ b/sensu-plugins-flowdock.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
   s.version                = SensuPluginsFlowdock::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin',      '1.1.0'
+  s.add_runtime_dependency 'flowdock',          '~>0.6'
 
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
   s.add_development_dependency 'rubocop',                   '0.30'


### PR DESCRIPTION
Adds the ability to pass in the following parameters in flowdock.json,
client.json, or check.json.
- auth_token
- tags
- user_name
